### PR TITLE
Fix PHP 8.4 deprecation: explicitly mark nullable constructor parameter

### DIFF
--- a/src/QueryFilters.php
+++ b/src/QueryFilters.php
@@ -35,7 +35,7 @@ abstract class QueryFilters
      *
      * @param \Illuminate\Http\Request|null $request
      */
-    public function __construct(Request $request = null)
+    public function __construct(?Request $request = null)
     {
         // do not inject requests to support Laravel Octane
         // @todo: remove constructor in the next major release


### PR DESCRIPTION
## Summary

This PR fixes a PHP 8.4 deprecation warning:

> Implicitly marking parameter `$request` as nullable is deprecated

The constructor now explicitly declares the `Request` parameter as nullable using `?Request $request = null`.

This change is fully backward-compatible with previous PHP versions and avoids deprecation errors in newer ones.

No functional logic was changed.
